### PR TITLE
Document.purge unused

### DIFF
--- a/src/DynamoRevitIcons/RevitNodesImages.resx
+++ b/src/DynamoRevitIcons/RevitNodesImages.resx
@@ -9461,4 +9461,51 @@
         KpMAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="Revit.Application.Document.PurgeUnused.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAGEAAABhCAYAAADGBs+jAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAYDSURBVHhe7ZzRShxXHMbzCD6Cj+CNIWk2Ro1W19UqEkKw
+        FFJKe1FKkZaiUFAvWnq1paCGXJWA0YCFEulFWkjEvkEewYve2dC9SUpo6fT/LZ7l7PHb3dnd/5w5456L
+        H7jfzKznfD93zuxkN1eSJInkDA0jfqFhxC80jPiFhhG/0DDiFxpG/ELDiF9oGPELDSN+oWHELzSM+IWG
+        Eb/QMOIXGkb8QsOIX2iYNYeHhyPCuAeG2e8PDRpmgRQyJGwJNSHxyH02npCgoTZSBP7yT61ifBO0CBpq
+        IgVAgO+/fkawImioiUy+6RWwv7//z9raWrK8vJwZOzs7dvk2QYqgoRaYtF3C7u7uv1NTU8no6GimVKtV
+        u3iX4ETQUAuZ8Eu7gEqlQkvTpoMEEJQIGmphT1yKOWOFZYEtAT9vbGw0HlsEI4KGGsgkh+1Jr6+vn7LC
+        ssCVgCxkETTUQCaIN0uNCectAYQqgoYayOSCkwBCFEFDDWRiQUoAoYmgoQYyqWAlgBYifmBzyRoaaiAT
+        CloCaCHiEZtPltBQA5lM8BJACCJoqIFMpBASQN4iaKiBTKIwEkCeImiogUwgCAl7e3upb5fkJYKGGsjg
+        c5PQosx+2GJz1IKGGsjAc5OAO7X271agxuaoBQ01kIHnJgGsrKzUT0X2GPrBnZ8mNNRABp6rBFAqleoy
+        VldXu2Z7e/sve/zu/DShoQYy8Nwl9APGa4/fnZ8mNNRABh4lpISGGsjAo4SU0FADGXiUkBIaaiADjxJS
+        QkMNZOBRQkpoqIEMPEpICQ01kIFHCSmhoQYy8CghJTTUQAaemYR7N95Jfnx3Kvl9vlznyex08mHpBt23
+        V6KENnw6drNRvgu2sWN6IUpoQTsB4LfKLD2uF6IEgiugenuyfloCdo7H7PhuiRIcmAB7u70tSrCQgatI
+        6CRg8fr1pu0z1641be+VKOGcNAKwDpjtD6ZvN23vhyhB6FYALlPHrl5t2qcfBl5C3gLAQEsIQQC4tBJw
+        5YJS8W4XfD1xq2khDUUAuHQSfnr8ODm6e+dvu2CbbybHgxIALpWEnx8+TE6WF5sK7kTeAsClkfDLd982
+        lQu+uDVWnyRKxOnI3R6CAFB4CVLW0PG9u7+a4mzcEtudhvISAAotQcoaFl6a4sDu/FzyfGHuP/M4jYg8
+        BYDCSpCyloSaKe7F4kLy+eREfVKdSnVF2PgWAAopQcrasos7qpRrKN6eWC8i8hAACiVBihoSTuzi5D3A
+        WaviuhXhLtS+KIwEKWlEOLVL25oYr7FJ2XQrQuv2dDcUQoKUc19onP+PK+U33ZTVSQQuZc02zbujaQle
+        ghTzyBQEnpZnXvVyH7+TCHnexjb7OB8EK0HKuHD5uT09+YpNIi3tRNifqHCPy5qQJTQW4OP58uvPxm6+
+        YRNAiTiFoESc39k+Nq1EmFcCtrHjsqQQEo7KM/QKCBlKNPvh1oS7D8MVYf8c1wQLKQRXQ43FGGuBLQJF
+        2udxFInMnlw7XBGGeHXkIKVQEW6BkNGNAAM+SWeeA6R9JWlTrVbPgpUApJwLImwB7lWOAX/R7f6q3VNZ
+        HqchgC8cHhwcvLUknLAetKBhGqSkJhGGVgLwDzdmH3ebAe+OzT54JbHn8QH5Mnq4XyaXsppEPK/MvmXv
+        F9x3wO52d59u1xIt8AogAvAf6w6x+WtBw26Q0tou1q4AdsmKwu19Hnzy8Z9YGH2xubn5h/u9ZYtVNm9N
+        aNgtUhwVgfO/yQBOSa4A7Pds6b3GPs+++pIVkRfF+l9epMC2i3Wru6FPFhca+7z44H1WRB7gFJT5K8BA
+        w16RIuli3UrA9/NzjX3wYQB8KsMpwyd4X3AirAqZrgEuNOwHKfSCCLZYf1Qqvbb3EcbZ8w0CNOwXKbTt
+        Yo2FGLe+zXbB20s/RGiogRRLRQDcdzK58JQdP0jQUAsp+III3Po2jwXcFvd6/g0RGmoiJdPF+jwbYccM
+        GjTUBmWfl25LWGL7DiI0zAIp3RaR6b2YokHDLIEMlg8yNIz4hYYRv9Aw4hcaRvxCw4hfaBjxCw0jfqFh
+        xCfJlf8BzbTE1V+oXb0AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="Revit.Application.Document.PurgeUnused.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACEAAAAhCAYAAABX5MJvAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAIPSURBVFhH7Za7TgJRFEX9BD7FBuJzHPEFjhGlslNbQ0E0
+        ComGUBg6YkNJtBEk2GBFNDHiH5j4A/Y0aqExJh7PnuSSy3iQGUbHxmLl3myGs9c8yDBERH+OGAaNGAaN
+        GAaNGAaNGDqp1+shxnRBSPp+P8RQhwcPM48M9aNWq93z6llEDHV46B0KcrkchcPhnvgREUMdDC4Wi22p
+        WAfHFQoFqlQq77yHuGsRMdTB8Gw2+yAV6+C4dDpNlmVRtVp98yIihjpeJbD3KiKGOm4l8MyUy2XcOhvs
+        8V2ISHN1xFDHrQTIZDIdCVAqlWwR50wnYqjjRcJJMpn8l7D5dYnE6ChdWjFqxBdof3qq6zPFr0oogeJM
+        lLanjOAldIEtY5Jul+K0OTH+RQD8mMT56SmdbK4/4myBUwCrJAB+RIJLzJvVZbvsLDZnAwncgn4CwLcE
+        l6RRtMdnnTKND+xRDhE3AmBgCS4IMY1rK/a6Nj7WGaguP0Twi9DLeuFHotFcjD0bkYj9wB1Gzc5QJYJb
+        sjAy0lUo4UdiA0VHs9E3rChGIaQwGA+lW4l8Po83KY/t7nAihrqI+kliBVecH6wk7LP8DiXADP4WVSIs
+        8IFbgitxsZqg5u6OfYld0mKGpfk6YqhQIilj8uV4frbN+5Z0nF/EUEeJtJbiT7x6/iftBjF0wuUm0/ey
+        DooYBo0YBo0YBgsNfQK0wkcTglWypgAAAABJRU5ErkJggg==
+</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -68,6 +68,19 @@ namespace Revit.Application
             get { return new Document(DocumentManager.Instance.CurrentDBDocument); }
         }
 
+        private List<PerformanceAdviserRuleId> performanceAdviserRuleIds;
+        private List<PerformanceAdviserRuleId> PerformanceAdviserRuleIds
+        {
+            get
+            {
+                if (performanceAdviserRuleIds == null)
+                {
+                    performanceAdviserRuleIds = GetPerfromanceAdviserRuleIdForPurge();
+                }
+                return performanceAdviserRuleIds;
+            }
+        }
+
         /// <summary>
         /// Gets the worksharing path of the current document
         /// </summary>
@@ -118,15 +131,19 @@ namespace Revit.Application
 
         private List<ElementId> PurgeMaterials()
         {
-            List<Autodesk.Revit.DB.ElementId> materials = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(Autodesk.Revit.DB.Material))
-                                                                                                           .ToElementIds()
-                                                                                                           .ToList();
+            List<Autodesk.Revit.DB.ElementId> materials = new FilteredElementCollector(this.InternalDocument)
+                .OfClass(typeof(Autodesk.Revit.DB.Material))
+                .ToElementIds()
+                .ToList();
+
             if (materials == null)
                 return new List<ElementId>();
 
-            List<Autodesk.Revit.DB.Element> elementTypes = new FilteredElementCollector(this.InternalDocument).WhereElementIsElementType()
-                                                                                                              .ToElements()
-                                                                                                              .ToList();
+            List<Autodesk.Revit.DB.Element> elementTypes = new FilteredElementCollector(this.InternalDocument)
+                .WhereElementIsElementType()
+                .ToElements()
+                .ToList();
+
             if (elementTypes == null)
                 return new List<ElementId>();
 
@@ -175,13 +192,16 @@ namespace Revit.Application
 
         private List<Autodesk.Revit.DB.ElementId> PurgeMaterialAssets(List<Autodesk.Revit.DB.ElementId> elementIds)
         {
-            List<ElementId> appearanceAssetIds = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(AppearanceAssetElement))
-                                                                                                    .ToElementIds()
-                                                                                                    .ToList();
+            List<ElementId> appearanceAssetIds = new FilteredElementCollector(this.InternalDocument)
+                .OfClass(typeof(AppearanceAssetElement))
+                .ToElementIds()
+                .ToList();
 
-            List<ElementId> propertySet = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(PropertySetElement))
-                                                                                             .ToElementIds()
-                                                                                             .ToList();
+            List<ElementId> propertySet = new FilteredElementCollector(this.InternalDocument)
+                .OfClass(typeof(PropertySetElement))
+                .ToElementIds()
+                .ToList();
+
             int elementIdsCount = elementIds.Count();
             for (int i = 0; i < elementIdsCount; i++)
             {
@@ -203,7 +223,7 @@ namespace Revit.Application
             if (propertySet.Count > 0)
                 this.InternalDocument.Delete(propertySet);
 
-            List<ElementId> purgedElementIds = new List<ElementId>(appearanceAssetIds.Concat(propertySet));
+            var purgedElementIds = new List<ElementId>(appearanceAssetIds.Concat(propertySet));
             return purgedElementIds;
         }
 
@@ -216,10 +236,12 @@ namespace Revit.Application
             {
                 if (purgeableElementIds == null)
                     return purgedElementIds;
+
                 purgedElementIds.AddRange(purgeableElementIds);
                 this.InternalDocument.Delete(purgeableElementIds);
                 return purgedElementIds;
             }
+
             if (purgeableElementIds == null)
                 return purgedElementIds;
 
@@ -233,7 +255,7 @@ namespace Revit.Application
         private List<Autodesk.Revit.DB.ElementId> GetPurgeableElementIds()
         {
             List<Autodesk.Revit.DB.FailureMessage> failureMessages = PerformanceAdviser.GetPerformanceAdviser()
-                                                                                       .ExecuteRules(this.InternalDocument, GetPerfromanceAdviserRuleId())
+                                                                                       .ExecuteRules(this.InternalDocument, PerformanceAdviserRuleIds)
                                                                                        .ToList();
             if (failureMessages.Count > 0)
             {
@@ -243,7 +265,7 @@ namespace Revit.Application
             return null;
         }
 
-        private static List<PerformanceAdviserRuleId> GetPerfromanceAdviserRuleId()
+        private static List<PerformanceAdviserRuleId> GetPerfromanceAdviserRuleIdForPurge()
         {
             //The internal GUID of the purge Performance Adviser Rule 
             const string purgePerformanceAdviserRuleGuid = "e8c63650-70b7-435a-9010-ec97660c1bda";

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -121,7 +121,7 @@ namespace Revit.Application
         /// <summary>
         /// Purge unused Elements from the model.
         /// </summary>
-        /// <param name="deepPurge">Similar to clicking the purge button multiple times in Revit.</param>
+        /// <param name="deepPurge">Similar to clicking the purge button multiple times in Revit, the node will repeatedly purge until there is nothing left to remove.</param>
         /// <returns>Purged element ids</returns>
         public List<int> PurgeUnused(bool deepPurge = false)
         {

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -199,7 +199,7 @@ namespace Revit.Application
 
         private List<Autodesk.Revit.DB.ElementId> PurgeMaterialAssets(List<Autodesk.Revit.DB.ElementId> elementIds)
         {
-            List<ElementId> appearanceAssets = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(AppearanceAssetElement))
+            List<ElementId> appearanceAssetIds = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(AppearanceAssetElement))
                                                                                       .ToElementIds().ToList();
 
             List<ElementId> propertySet = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(PropertySetElement))

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -231,6 +231,8 @@ namespace Revit.Application
             
             if (!runRecursively)
             {
+                if (purgableElementIds == null)
+                    return purgedElementIds;
                 purgedElementIds.AddRange(purgableElementIds);
                 this.InternalDocument.Delete(purgableElementIds);
                 return purgedElementIds;

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -3,7 +3,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Revit.Elements;
 using Revit.GeometryConversion;
-
+using System;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 using System;
@@ -68,6 +68,29 @@ namespace Revit.Application
             get { return new Document(DocumentManager.Instance.CurrentDBDocument); }
         }
 
+        public void PurgeUnusedPostableCommand(bool deepPurge)
+        {
+            //The internal GUID of the Performance Adviser Rule 
+            const string purgeGuid = "e8c63650-70b7-435a-9010-ec97660c1bda";
+            IList<PerformanceAdviserRuleId> performanceAdviserRules = PerformanceAdviser.GetPerformanceAdviser().GetAllRuleIds();
+            List<PerformanceAdviserRuleId> performanceAdviserRuleId = performanceAdviserRules.Where(x => x.Guid.ToString() == purgeGuid).ToList();
+
+            UIApplication uiApp = DocumentManager.Instance.CurrentUIApplication;
+            uiApp.DialogBoxShowing += UiApp_DialogBoxShowing;
+            TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
+            List<ElementId> purgedElements = PurgeElements(performanceAdviserRuleId, deepPurge);
+            var postableCmdID = RevitCommandId.LookupCommandId("ID_PURGE_UNUSED");
+            uiApp.PostCommand(postableCmdID);
+            TransactionManager.Instance.TransactionTaskDone();
+            uiApp.DialogBoxShowing -= UiApp_DialogBoxShowing;
+        }
+
+        private void UiApp_DialogBoxShowing(object sender, Autodesk.Revit.UI.Events.DialogBoxShowingEventArgs e)
+        {
+            e.OverrideResult(1);
+        }
+
+
         /// <summary>
         /// Gets the worksharing path of the current document
         /// </summary>
@@ -94,63 +117,139 @@ namespace Revit.Application
         {
             get { return this.InternalDocument.GetWorksharingCentralModelPath(); }
         }
+
         /// <summary>
-        /// Purge unused Elements from the model. This node is not able to purge materials and material assets
+        /// Purge unused Elements from the model.
         /// </summary>
         /// <param name="deepPurge">Similar to clicking the purge button multiple times in Revit.</param>
-        /// <returns></returns>
-        public string PurgeUnused(bool deepPurge)
+        /// <returns>Purged element ids</returns>
+        public List<int> PurgeUnused(bool deepPurge = false)
         {
             //The internal GUID of the Performance Adviser Rule 
             const string purgeGuid = "e8c63650-70b7-435a-9010-ec97660c1bda";
 
-            var performanceAdviserRuleId = new List<PerformanceAdviserRuleId>();
-            var performanceAdviserRules = PerformanceAdviser.GetPerformanceAdviser().GetAllRuleIds();
-
-            //Iterating through all PerformanceAdviser rules looking to find that which matches PURGE_GUID
-            for (int i = 0; i < performanceAdviserRules.Count; i++)
-            {
-                if (performanceAdviserRules[i].Guid.ToString() == purgeGuid)
-                {
-                    performanceAdviserRuleId.Add(performanceAdviserRules[i]);
-                    break;
-                }
-            }
-
+            IList<PerformanceAdviserRuleId> performanceAdviserRules = PerformanceAdviser.GetPerformanceAdviser().GetAllRuleIds();
+            List<PerformanceAdviserRuleId> performanceAdviserRuleId = performanceAdviserRules.Where(x => x.Guid.ToString() == purgeGuid).ToList();
+            List<ElementId> purgedElementIds = new List<ElementId>();
             TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
-            int purgeCount = purgeElements(this.InternalDocument, performanceAdviserRuleId, deepPurge);
+            
+            purgedElementIds.AddRange(PurgeElements(performanceAdviserRuleId, deepPurge));
+            purgedElementIds.AddRange(PurgeMaterials());
+
             TransactionManager.Instance.TransactionTaskDone();
-            if (purgeCount == 0)
-            {
-                return Properties.Resources.NoElementsToPurge;
 
-            }
-            return string.Format(Properties.Resources.PurgedElements, purgeCount);
+            if (purgedElementIds.Count == 0)
+                throw new InvalidOperationException(Properties.Resources.NoElementsToPurge);
+
+            return purgedElementIds.Select(x => x.IntegerValue).ToList();
         }
 
-        private static int purgeElements(Autodesk.Revit.DB.Document document, List<PerformanceAdviserRuleId> performanceAdviserRuleId, bool runRecursively)
+        private List<ElementId> PurgeMaterials()
         {
-            int purgedElements = 0;
-            List<ElementId> purgeableElementIds = getPurgeableElementIds(document, performanceAdviserRuleId);
-            if (purgeableElementIds == null)
-            {
-                return purgedElements;
-            }
-            if (runRecursively && purgeableElementIds.Count > 0)
-            {
-                purgedElements += purgeableElementIds.Count;
-                document.Delete(purgeableElementIds);
-                return purgedElements += purgeElements(document, performanceAdviserRuleId, runRecursively);
-            }
-            purgedElements += purgeableElementIds.Count;
-            document.Delete(purgeableElementIds);
-            return purgedElements;
+            List<Autodesk.Revit.DB.ElementId> materials = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(Autodesk.Revit.DB.Material))
+                                                                                                           .ToElementIds()
+                                                                                                           .ToList();
 
+            List<Autodesk.Revit.DB.Element> elementTypes = new FilteredElementCollector(this.InternalDocument).WhereElementIsElementType()
+                                                                                                              .ToElements()
+                                                                                                              .ToList();
+            var nonPurgedElements = new List<Autodesk.Revit.DB.ElementId>();
+
+            for (int i = 0; i < elementTypes.Count; i++)
+            {
+                HostObjAttributes hostObj = elementTypes[i] as HostObjAttributes;
+                if (hostObj != null)
+                {
+                    var compundStructure = hostObj.GetCompoundStructure();
+                    if (compundStructure == null)
+                        continue;
+
+                    int layerCount = compundStructure.LayerCount;
+                    for (int j = 0; j < layerCount; j++)
+                    {
+                        ElementId elementId = compundStructure.GetMaterialId(j);
+                        if (materials.Contains(elementId))
+                        {
+                            nonPurgedElements.Add(elementId);
+                            materials.Remove(elementId);
+                        }
+                        
+                    }
+                    continue;
+                }
+
+                List<ElementId> elementMaterialIds = elementTypes[i].GetMaterialIds(false).ToList();
+                if (elementMaterialIds.Any())
+                {
+                    materials.RemoveAll(purgedId => elementMaterialIds.Exists(elemId => purgedId == elemId));
+                    nonPurgedElements.AddRange(elementMaterialIds.Where(elmeMatId => !nonPurgedElements.Any(nonPurgedElemeMatId => nonPurgedElemeMatId == elmeMatId)));
+                }
+
+                if (materials == null)
+                    break;
+            }
+            if (materials.Count > 0)
+                this.InternalDocument.Delete(materials);
+            List<ElementId> purgedMaterials = new List<ElementId>();
+            purgedMaterials.AddRange(PurgeMaterialAssets(nonPurgedElements));
+            purgedMaterials.AddRange(materials);
+
+            return purgedMaterials;
         }
-        private static List<Autodesk.Revit.DB.ElementId> getPurgeableElementIds(Autodesk.Revit.DB.Document document, List<PerformanceAdviserRuleId> performanceAdviserRuleId)
+
+        private List<Autodesk.Revit.DB.ElementId> PurgeMaterialAssets(List<Autodesk.Revit.DB.ElementId> elementIds)
         {
-            List<Autodesk.Revit.DB.FailureMessage> failureMessages = PerformanceAdviser.GetPerformanceAdviser().ExecuteRules(document,
-                                                                                                                             performanceAdviserRuleId).ToList();
+            List<ElementId> appearanceAssets = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(AppearanceAssetElement))
+                                                                                      .ToElementIds().ToList();
+
+            List<ElementId> propertySet = new FilteredElementCollector(this.InternalDocument).OfClass(typeof(PropertySetElement))
+                                                                                                      .ToElementIds().ToList();
+
+            for (int i = 0; i < elementIds.Count(); i++)
+            {
+                Autodesk.Revit.DB.Material material = this.InternalDocument.GetElement(elementIds[i]) as Autodesk.Revit.DB.Material;
+                propertySet.Remove(material.ThermalAssetId);
+                propertySet.Remove(material.StructuralAssetId);
+                appearanceAssets.Remove(material.AppearanceAssetId);
+            }
+
+            if (appearanceAssets.Count > 0)
+                this.InternalDocument.Delete(appearanceAssets);
+            if (propertySet.Count > 0)
+                this.InternalDocument.Delete(propertySet);
+
+            List<ElementId> purgedElementIds = new List<ElementId>();
+            purgedElementIds.AddRange(appearanceAssets);
+            purgedElementIds.AddRange(propertySet);
+            return purgedElementIds;
+        }
+
+        private List<ElementId> PurgeElements(List<PerformanceAdviserRuleId> performanceAdviserRuleId, bool runRecursively)
+        {
+            List<ElementId> purgedElementIds = new List<ElementId>();
+            List<ElementId> purgableElementIds = GetPurgeableElementIds(performanceAdviserRuleId);
+            
+            if (!runRecursively)
+            {
+                purgedElementIds.AddRange(purgableElementIds);
+                this.InternalDocument.Delete(purgableElementIds);
+                return purgedElementIds;
+            }
+            if (purgableElementIds == null)
+                return purgedElementIds;
+
+            purgedElementIds.AddRange(purgableElementIds);
+            this.InternalDocument.Delete(purgableElementIds);
+            purgedElementIds.AddRange(PurgeElements(performanceAdviserRuleId, runRecursively));
+
+            return purgedElementIds;
+        }
+
+        private List<Autodesk.Revit.DB.ElementId> GetPurgeableElementIds(List<PerformanceAdviserRuleId> performanceAdviserRuleId)
+        {
+            List<Autodesk.Revit.DB.FailureMessage> failureMessages = PerformanceAdviser.GetPerformanceAdviser()
+                                                                                       .ExecuteRules(this.InternalDocument, performanceAdviserRuleId)
+                                                                                       .ToList();
             if (failureMessages.Count > 0)
             {
                 List<ElementId> purgeableElementIds = failureMessages[0].GetFailingElements().ToList();

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -151,7 +151,7 @@ namespace Revit.Application
 
             for (int i = 0; i < elementTypes.Count; i++)
             {
-                nonPurgedElements.UnionWith(GetNonPurgableMaterialIds(elementTypes[i]));
+                nonPurgedElements.UnionWith(GetNonPurgeableMaterialIds(elementTypes[i]));
             }
 
             List<ElementId> purgeableMaterials = materials.Except(nonPurgedElements).ToList();
@@ -163,7 +163,7 @@ namespace Revit.Application
             return purgeableMaterials.Concat(purgedMaterialAssets).ToList();
         }
 
-        private static HashSet<ElementId> GetNonPurgableMaterialIds(Autodesk.Revit.DB.Element type)
+        private static HashSet<ElementId> GetNonPurgeableMaterialIds(Autodesk.Revit.DB.Element type)
         {
             HostObjAttributes hostObj = type as HostObjAttributes;
             HashSet<ElementId> usedMaterialIds = new HashSet<ElementId>();
@@ -179,12 +179,10 @@ namespace Revit.Application
                     }
                 }
             }
-
             List<ElementId> elementMaterialIds = type.GetMaterialIds(false).ToList();
             if (elementMaterialIds.Any())
-            {
                 usedMaterialIds.UnionWith(elementMaterialIds);
-            }
+            
             return usedMaterialIds;
         }
 

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -98,14 +98,14 @@ namespace Revit.Application
         /// <summary>
         /// Purge unused Elements from the model.
         /// </summary>
-        /// <param name="deepPurge">Similar to clicking the purge button multiple times in Revit, the node will repeatedly purge until there is nothing left to remove.</param>
+        /// <param name="fullPurge">Similar to clicking the purge button multiple times in Revit, the node will repeatedly purge until there is nothing left to remove.</param>
         /// <returns>Purged element ids</returns>
-        public List<int> PurgeUnused(bool deepPurge = false)
+        public List<int> PurgeUnused(bool fullPurge = false)
         {
             List<ElementId> purgedElementIds = new List<ElementId>();
             TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
 
-            purgedElementIds.AddRange(PurgeElements(deepPurge));
+            purgedElementIds.AddRange(PurgeElements(fullPurge));
             purgedElementIds.AddRange(PurgeMaterials());
 
             TransactionManager.Instance.TransactionTaskDone();

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -97,8 +97,9 @@ namespace Revit.Application
         /// <summary>
         /// Purge unused Elements from the model. This node is not able to purge materials and material assets
         /// </summary>
+        /// <param name="deepPurge">Similar to clicking the purge button multiple times in Revit.</param>
         /// <returns></returns>
-        public string PurgeUnused(bool runRecursively)
+        public string PurgeUnused(bool deepPurge)
         {
             //The internal GUID of the Performance Adviser Rule 
             const string purgeGuid = "e8c63650-70b7-435a-9010-ec97660c1bda";
@@ -117,7 +118,7 @@ namespace Revit.Application
             }
 
             TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
-            int purgeCount = purgeElements(this.InternalDocument, performanceAdviserRuleId, runRecursively);
+            int purgeCount = purgeElements(this.InternalDocument, performanceAdviserRuleId, deepPurge);
             TransactionManager.Instance.TransactionTaskDone();
             if (purgeCount == 0)
             {

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -125,11 +125,11 @@ namespace Revit.Application
         /// <returns>Purged element ids</returns>
         public List<int> PurgeUnused(bool deepPurge = false)
         {
-            //The internal GUID of the Performance Adviser Rule 
-            const string purgeGuid = "e8c63650-70b7-435a-9010-ec97660c1bda";
+            //The internal GUID of the purge Performance Adviser Rule 
+            const string purgePerformanceAdviserRuleGuid = "e8c63650-70b7-435a-9010-ec97660c1bda";
 
             IList<PerformanceAdviserRuleId> performanceAdviserRules = PerformanceAdviser.GetPerformanceAdviser().GetAllRuleIds();
-            List<PerformanceAdviserRuleId> performanceAdviserRuleId = performanceAdviserRules.Where(x => x.Guid.ToString() == purgeGuid).ToList();
+            List<PerformanceAdviserRuleId> performanceAdviserRuleId = performanceAdviserRules.Where(x => x.Guid.ToString() == purgePerformanceAdviserRuleGuid).ToList();
             List<ElementId> purgedElementIds = new List<ElementId>();
             TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
             

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -700,7 +700,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No Elements to purge in the current document.
+        ///   Looks up a localized string similar to No Elements to purge in the current document..
         /// </summary>
         internal static string NoElementsToPurge {
             get {
@@ -876,15 +876,6 @@ namespace Revit.Properties {
         internal static string PolyCurvesConversionError {
             get {
                 return ResourceManager.GetString("PolyCurvesConversionError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Purged {0} elements, form the current document.
-        /// </summary>
-        internal static string PurgedElements {
-            get {
-                return ResourceManager.GetString("PurgedElements", resourceCulture);
             }
         }
         

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -700,6 +700,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No Elements to purge in the current document.
+        /// </summary>
+        internal static string NoElementsToPurge {
+            get {
+                return ResourceManager.GetString("NoElementsToPurge", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No shared parameter file found..
         /// </summary>
         internal static string NoSharedParameterFileFound {
@@ -867,6 +876,15 @@ namespace Revit.Properties {
         internal static string PolyCurvesConversionError {
             get {
                 return ResourceManager.GetString("PolyCurvesConversionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Purged {0} elements, form the current document.
+        /// </summary>
+        internal static string PurgedElements {
+            get {
+                return ResourceManager.GetString("PurgedElements", resourceCulture);
             }
         }
         

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -430,9 +430,6 @@
     <value>Current Document is not workshared</value>
   </data>
   <data name="NoElementsToPurge" xml:space="preserve">
-    <value>No Elements to purge in the current document</value>
-  </data>
-  <data name="PurgedElements" xml:space="preserve">
-    <value>Purged {0} elements, form the current document</value>
+    <value>No Elements to purge in the current document.</value>
   </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -429,4 +429,10 @@
   <data name="DocumentNotWorkshared" xml:space="preserve">
     <value>Current Document is not workshared</value>
   </data>
+  <data name="NoElementsToPurge" xml:space="preserve">
+    <value>No Elements to purge in the current document</value>
+  </data>
+  <data name="PurgedElements" xml:space="preserve">
+    <value>Purged {0} elements, form the current document</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -454,9 +454,6 @@
     <value>Current Document is not workshared</value>
   </data>
   <data name="NoElementsToPurge" xml:space="preserve">
-    <value>No Elements to purge in the current document</value>
-  </data>
-  <data name="PurgedElements" xml:space="preserve">
-    <value>Purged {0} elements, form the current document</value>
+    <value>No Elements to purge in the current document.</value>
   </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -453,4 +453,10 @@
   <data name="DocumentNotWorkshared" xml:space="preserve">
     <value>Current Document is not workshared</value>
   </data>
+  <data name="NoElementsToPurge" xml:space="preserve">
+    <value>No Elements to purge in the current document</value>
+  </data>
+  <data name="PurgedElements" xml:space="preserve">
+    <value>Purged {0} elements, form the current document</value>
+  </data>
 </root>

--- a/test/Libraries/RevitIntegrationTests/DocumentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DocumentTests.cs
@@ -12,7 +12,7 @@ using RTF.Framework;
 namespace RevitSystemTests
 {
     [TestFixture]
-    class DocumentTests : RevitSystemTestBase
+    public class DocumentTests : RevitSystemTestBase
     {
         [Test]
         [TestModel(@"./empty.rfa")]
@@ -141,12 +141,32 @@ namespace RevitSystemTests
             // Act
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
+
             string resultWorksharingPath = GetPreviewValue("3f5e9a8cb7344c52a3c4937455ee68b1") as string;
             var resultIsCloudPath = GetPreviewValue("1b62b04935b84f58a31bf45efe48955d");
 
             // Assert
             Assert.IsTrue(resultWorksharingPath.Contains(expectedWorksharingFilePath));
             Assert.AreEqual(expectedIsCloudPathResult, resultIsCloudPath);
+        }
+
+        [Test]
+        [TestModel(@".\SampleModel.rvt")]
+        public void CanPurgeUnusedElementsFromDocument()
+        {
+            // Arange
+            string samplePath = Path.Combine(workingDirectory, @".\Document\canPurgeUnusedElementsFromDocument.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+            int expectedPurgedElementNumber = 19;
+            string expectedNodeOutput = string.Format("Purged {0} elements, form the current document", expectedPurgedElementNumber);
+
+            // Act
+            ViewModel.OpenCommand.Execute(testPath);
+            RunCurrentModel();
+            var purgeUnusedOutput = GetPreviewValue("7997eedbf6bd4822b5ca8b8cf0819de2");
+
+            // Assert
+            Assert.AreEqual(purgeUnusedOutput, expectedNodeOutput);
         }
     }
 }

--- a/test/Libraries/RevitIntegrationTests/DocumentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DocumentTests.cs
@@ -158,7 +158,7 @@ namespace RevitSystemTests
             // Arange
             string samplePath = Path.Combine(workingDirectory, @".\Document\canPurgeUnusedElementsFromDocument.dyn");
             string testPath = Path.GetFullPath(samplePath);
-            var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 208080, 210695, 416 };
+            var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 416, 208080, 210695 };
 
             // Act
             ViewModel.OpenCommand.Execute(testPath);

--- a/test/Libraries/RevitIntegrationTests/DocumentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DocumentTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+
 using NUnit.Framework;
 
 using RevitServices.Persistence;
@@ -157,16 +158,15 @@ namespace RevitSystemTests
             // Arange
             string samplePath = Path.Combine(workingDirectory, @".\Document\canPurgeUnusedElementsFromDocument.dyn");
             string testPath = Path.GetFullPath(samplePath);
-            int expectedPurgedElementNumber = 396;
-            string expectedNodeOutput = string.Format("Purged {0} elements, form the current document", expectedPurgedElementNumber);
+            var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 208080, 210695, 416 };
 
             // Act
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
-            var purgeUnusedOutput = GetPreviewValue("7997eedbf6bd4822b5ca8b8cf0819de2");
+            var purgeUnusedOutput = GetPreviewCollection("7997eedbf6bd4822b5ca8b8cf0819de2");
 
             // Assert
-            Assert.AreEqual(purgeUnusedOutput, expectedNodeOutput);
+            CollectionAssert.AreEqual(purgeUnusedOutput, expectedPurgedElementIds);
         }
     }
 }

--- a/test/Libraries/RevitIntegrationTests/DocumentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DocumentTests.cs
@@ -151,13 +151,13 @@ namespace RevitSystemTests
         }
 
         [Test]
-        [TestModel(@".\SampleModel.rvt")]
+        [TestModel(@".\Document\DocumentPurgeUnusedTest.rvt")]
         public void CanPurgeUnusedElementsFromDocument()
         {
             // Arange
             string samplePath = Path.Combine(workingDirectory, @".\Document\canPurgeUnusedElementsFromDocument.dyn");
             string testPath = Path.GetFullPath(samplePath);
-            int expectedPurgedElementNumber = 19;
+            int expectedPurgedElementNumber = 396;
             string expectedNodeOutput = string.Format("Purged {0} elements, form the current document", expectedPurgedElementNumber);
 
             // Act

--- a/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
@@ -145,7 +145,7 @@ namespace RevitNodesTests.Elements
 
             // Act
             var document = Document.Current;
-            var resultFirstRun = document.PurgeUnused(false);
+            var resultFirstRun = document.PurgeUnused();
 
             // Assert
             Assert.AreEqual(expectedPurgeMessageFirstRun, resultFirstRun);

--- a/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
@@ -114,5 +114,25 @@ namespace RevitNodesTests.Elements
             Directory.Delete(nonExistingTempFolder, true);
             Directory.Delete(existingTempFolder, true);
         }
+
+        [Test]
+        [TestModel(@".\SampleModel.rvt")]
+        public void CanPurgeUnusedElementsFromDocument()
+        {
+            // Arrange
+            int expectedPurgedElementNumber = 19;
+            string expectedPurgeMessageFirstRun = string.Format(Revit.Properties.Resources.PurgedElements, expectedPurgedElementNumber);
+            string expectedPurgeMessageSecondRun = Revit.Properties.Resources.NoElementsToPurge;
+
+            // Act
+            var document = Document.Current;
+            var resultFirstRun = document.PurgeUnused();
+            var resultSecondRun = document.PurgeUnused();
+
+            // Assert
+            Assert.AreEqual(expectedPurgeMessageFirstRun, resultFirstRun);
+            Assert.AreEqual(expectedPurgeMessageSecondRun, resultSecondRun);
+        }
+
     }
 }

--- a/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
@@ -6,6 +6,7 @@ using RevitTestServices;
 using RTF.Framework;
 using System;
 using System.IO;
+using System.Collections.Generic;
 
 namespace RevitNodesTests.Elements
 {
@@ -121,18 +122,17 @@ namespace RevitNodesTests.Elements
         public void CanRecursivelyPurgeUnusedElementsFromDocument()
         {
             // Arrange
-            int expectedPurgedElementNumber = 396;
-            string expectedPurgeMessageFirstRun = string.Format(Revit.Properties.Resources.PurgedElements, expectedPurgedElementNumber);
+            var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 208080, 210695, 416 };
             string expectedPurgeMessageSecondRun = Revit.Properties.Resources.NoElementsToPurge;
-
-            // Act
+            
+            // Act - second purge should throw exception as there is nothing left to purge after during PurgeUnused(true).
             var document = Document.Current;
             var resultFirstRun = document.PurgeUnused(true);
-            var resultSecondRun = document.PurgeUnused(true);
+            var resultSecondRun = Assert.Throws<System.InvalidOperationException>(() => document.PurgeUnused(true));
 
             // Assert
-            Assert.AreEqual(expectedPurgeMessageFirstRun, resultFirstRun);
-            Assert.AreEqual(expectedPurgeMessageSecondRun, resultSecondRun);
+            Assert.AreEqual(expectedPurgedElementIds, resultFirstRun);
+            Assert.AreEqual(expectedPurgeMessageSecondRun, resultSecondRun.Message);
         }
 
         [Test]
@@ -140,15 +140,17 @@ namespace RevitNodesTests.Elements
         public void CanPurgeUnusedElementsFromDocument()
         {
             // Arrange
-            int expectedPurgedElementNumber = 393;
-            string expectedPurgeMessageFirstRun = string.Format(Revit.Properties.Resources.PurgedElements, expectedPurgedElementNumber);
+            var expectedPurgedElementIdsFirstRun = new List<int>() { 217063, 221347 };
+            var expectedPurgedElementIdsSecondRun = new List<int>() { 216753,208080,210695,416 };
 
-            // Act
+            // Act - as we are not running recursivly, second run should return element ids
             var document = Document.Current;
             var resultFirstRun = document.PurgeUnused();
+            var resultSecondRun = document.PurgeUnused();
 
             // Assert
-            Assert.AreEqual(expectedPurgeMessageFirstRun, resultFirstRun);
+            Assert.AreEqual(expectedPurgedElementIdsFirstRun, resultFirstRun);
+            Assert.AreEqual(expectedPurgedElementIdsSecondRun, resultSecondRun);
         }
 
     }

--- a/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using Revit.Application;
 using Revit.Elements;
+using RevitServices.Transactions;
 using RevitTestServices;
 using RTF.Framework;
 using System;
@@ -116,22 +117,38 @@ namespace RevitNodesTests.Elements
         }
 
         [Test]
-        [TestModel(@".\SampleModel.rvt")]
-        public void CanPurgeUnusedElementsFromDocument()
+        [TestModel(@".\Document\DocumentPurgeUnusedTest.rvt")]
+        public void CanRecursivelyPurgeUnusedElementsFromDocument()
         {
             // Arrange
-            int expectedPurgedElementNumber = 19;
+            int expectedPurgedElementNumber = 396;
             string expectedPurgeMessageFirstRun = string.Format(Revit.Properties.Resources.PurgedElements, expectedPurgedElementNumber);
             string expectedPurgeMessageSecondRun = Revit.Properties.Resources.NoElementsToPurge;
 
             // Act
             var document = Document.Current;
-            var resultFirstRun = document.PurgeUnused();
-            var resultSecondRun = document.PurgeUnused();
+            var resultFirstRun = document.PurgeUnused(true);
+            var resultSecondRun = document.PurgeUnused(true);
 
             // Assert
             Assert.AreEqual(expectedPurgeMessageFirstRun, resultFirstRun);
             Assert.AreEqual(expectedPurgeMessageSecondRun, resultSecondRun);
+        }
+
+        [Test]
+        [TestModel(@".\Document\DocumentPurgeUnusedTest.rvt")]
+        public void CanPurgeUnusedElementsFromDocument()
+        {
+            // Arrange
+            int expectedPurgedElementNumber = 393;
+            string expectedPurgeMessageFirstRun = string.Format(Revit.Properties.Resources.PurgedElements, expectedPurgedElementNumber);
+
+            // Act
+            var document = Document.Current;
+            var resultFirstRun = document.PurgeUnused(false);
+
+            // Assert
+            Assert.AreEqual(expectedPurgeMessageFirstRun, resultFirstRun);
         }
 
     }

--- a/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
@@ -125,7 +125,7 @@ namespace RevitNodesTests.Elements
             var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 208080, 210695, 416 };
             string expectedPurgeMessageSecondRun = Revit.Properties.Resources.NoElementsToPurge;
             
-            // Act - second purge should throw exception as there is nothing left to purge after during PurgeUnused(true).
+            // Act - second purge should throw exception as there is nothing left to purge after doing PurgeUnused(true).
             var document = Document.Current;
             var resultFirstRun = document.PurgeUnused(true);
             var resultSecondRun = Assert.Throws<System.InvalidOperationException>(() => document.PurgeUnused(true));

--- a/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
@@ -122,7 +122,7 @@ namespace RevitNodesTests.Elements
         public void CanRecursivelyPurgeUnusedElementsFromDocument()
         {
             // Arrange
-            var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 208080, 210695, 416 };
+            var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 416, 208080, 210695 };
             string expectedPurgeMessageSecondRun = Revit.Properties.Resources.NoElementsToPurge;
             
             // Act - second purge should throw exception as there is nothing left to purge after doing PurgeUnused(true).
@@ -141,7 +141,7 @@ namespace RevitNodesTests.Elements
         {
             // Arrange
             var expectedPurgedElementIdsFirstRun = new List<int>() { 217063, 221347 };
-            var expectedPurgedElementIdsSecondRun = new List<int>() { 216753,208080,210695,416 };
+            var expectedPurgedElementIdsSecondRun = new List<int>() { 216753, 416, 208080, 210695 };
 
             // Act - as we are not running recursivly, second run should return element ids
             var document = Document.Current;

--- a/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
+++ b/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
@@ -1,0 +1,121 @@
+{
+  "Uuid": "31169b2c-eba9-41a6-aac7-50ea23993a67",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "canPurgeUnusedElementsFromDocument",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Application.Document.PurgeUnused",
+      "Id": "7997eedbf6bd4822b5ca8b8cf0819de2",
+      "Inputs": [
+        {
+          "Id": "20ae7b8a1d484b36b41562aee7ea9741",
+          "Name": "document",
+          "Description": "Revit.Application.Document",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7efde0d7a1c54cdcae0b4b012c810b66",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Document.PurgeUnused ( ): string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Application.Document.Current",
+      "Id": "6ccb93fe90094dbda5fe76a5a7385a76",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "97a42bb3f8424d4bb4017a9901b14363",
+          "Name": "Document",
+          "Description": "Document",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get the current document\n\nDocument.Current: Document"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "97a42bb3f8424d4bb4017a9901b14363",
+      "End": "20ae7b8a1d484b36b41562aee7ea9741",
+      "Id": "522909a253204c95ae61bfb51f785830"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.0.7034",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Document.PurgeUnused",
+        "Id": "7997eedbf6bd4822b5ca8b8cf0819de2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 299.33333333333331,
+        "Y": 169.33333333333334
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Document.Current",
+        "Id": "6ccb93fe90094dbda5fe76a5a7385a76",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 97.333333333333314,
+        "Y": 169.33333333333334
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
+++ b/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
@@ -27,7 +27,7 @@
         {
           "Id": "6492e6c52a594df7b4b8826cbcc0365c",
           "Name": "deepPurge",
-          "Description": "Similar to clicking the purge button multiple times in Revit.\n\nbool",
+          "Description": "Similar to clicking the purge button multiple times in Revit.\n\nbool\nDefault value : false (disabled)",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -37,7 +37,7 @@
       "Outputs": [
         {
           "Id": "7efde0d7a1c54cdcae0b4b012c810b66",
-          "Name": "var[]",
+          "Name": "int[]",
           "Description": "Purged element ids",
           "UsingDefaultValue": false,
           "Level": 2,
@@ -46,7 +46,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "Purge unused Elements from the model. This node is not able to purge materials and material assets\n\nDocument.PurgeUnused (deepPurge: bool): var[]"
+      "Description": "Purge unused Elements from the model.\n\nDocument.PurgeUnused (deepPurge: bool = false): int[]"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -93,7 +93,7 @@
     {
       "Start": "97a42bb3f8424d4bb4017a9901b14363",
       "End": "20ae7b8a1d484b36b41562aee7ea9741",
-      "Id": "522909a253204c95ae61bfb51f785830"
+      "Id": "2074118efc7f4458bc9c34048f41985a"
     },
     {
       "Start": "7367ee6542af4cb38293ad77b5134639",
@@ -154,12 +154,12 @@
         "IsSetAsOutput": false,
         "Excluded": false,
         "X": 90.000000000000028,
-        "Y": 271.33333333333337
+        "Y": 279.91702589409022
       }
     ],
     "Annotations": [],
-    "X": 350.6351385519489,
-    "Y": -61.032545380260274,
-    "Zoom": 1.2292518240025416
+    "X": -25.530921025464522,
+    "Y": 2.8976283518936725,
+    "Zoom": 0.8543331767099992
   }
 }

--- a/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
+++ b/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
@@ -25,9 +25,9 @@
           "KeepListStructure": false
         },
         {
-          "Id": "fe84fdef176b4cd6b126cb11691d8daa",
-          "Name": "runRecursively",
-          "Description": "bool",
+          "Id": "6492e6c52a594df7b4b8826cbcc0365c",
+          "Name": "deepPurge",
+          "Description": "Similar to clicking the purge button multiple times in Revit.\n\nbool",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -37,8 +37,8 @@
       "Outputs": [
         {
           "Id": "7efde0d7a1c54cdcae0b4b012c810b66",
-          "Name": "string",
-          "Description": "string",
+          "Name": "var[]",
+          "Description": "Purged element ids",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -46,7 +46,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "Purge unused Elements from the model. This node is not able to purge materials and material assets\n\nDocument.PurgeUnused (runRecursively: bool): string"
+      "Description": "Purge unused Elements from the model. This node is not able to purge materials and material assets\n\nDocument.PurgeUnused (deepPurge: bool): var[]"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -72,11 +72,11 @@
       "ConcreteType": "CoreNodeModels.Input.BoolSelector, CoreNodeModels",
       "NodeType": "BooleanInputNode",
       "InputValue": true,
-      "Id": "3bff80c32bcb436e9e5b0c9b24ba760d",
+      "Id": "36a526a6e7dc49279c09b4b719157aae",
       "Inputs": [],
       "Outputs": [
         {
-          "Id": "57c905adff5c414db87efcba669b8150",
+          "Id": "7367ee6542af4cb38293ad77b5134639",
           "Name": "",
           "Description": "Boolean",
           "UsingDefaultValue": false,
@@ -93,12 +93,12 @@
     {
       "Start": "97a42bb3f8424d4bb4017a9901b14363",
       "End": "20ae7b8a1d484b36b41562aee7ea9741",
-      "Id": "7457b7a8f38b4fa49af2c1e27cde3ffd"
+      "Id": "522909a253204c95ae61bfb51f785830"
     },
     {
-      "Start": "57c905adff5c414db87efcba669b8150",
-      "End": "fe84fdef176b4cd6b126cb11691d8daa",
-      "Id": "2a225f9fec2743269c0ed690d0529a1d"
+      "Start": "7367ee6542af4cb38293ad77b5134639",
+      "End": "6492e6c52a594df7b4b8826cbcc0365c",
+      "Id": "741dcb6cec39405fb847c00516f38221"
     }
   ],
   "Dependencies": [],
@@ -110,7 +110,7 @@
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
       "Version": "2.6.0.7034",
-      "RunType": "Automatic",
+      "RunType": "Manual",
       "RunPeriod": "1000"
     },
     "Camera": {
@@ -149,17 +149,17 @@
       {
         "ShowGeometry": true,
         "Name": "Boolean",
-        "Id": "3bff80c32bcb436e9e5b0c9b24ba760d",
+        "Id": "36a526a6e7dc49279c09b4b719157aae",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 102.66666666666657,
-        "Y": 263.33333333333331
+        "X": 90.000000000000028,
+        "Y": 271.33333333333337
       }
     ],
     "Annotations": [],
-    "X": -109.58882235528941,
-    "Y": -89.349301397205579,
-    "Zoom": 1.4341317365269461
+    "X": 350.6351385519489,
+    "Y": -61.032545380260274,
+    "Zoom": 1.2292518240025416
   }
 }

--- a/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
+++ b/test/System/Document/canPurgeUnusedElementsFromDocument.dyn
@@ -12,13 +12,22 @@
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
       "NodeType": "FunctionNode",
-      "FunctionSignature": "Revit.Application.Document.PurgeUnused",
+      "FunctionSignature": "Revit.Application.Document.PurgeUnused@bool",
       "Id": "7997eedbf6bd4822b5ca8b8cf0819de2",
       "Inputs": [
         {
           "Id": "20ae7b8a1d484b36b41562aee7ea9741",
           "Name": "document",
           "Description": "Revit.Application.Document",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "fe84fdef176b4cd6b126cb11691d8daa",
+          "Name": "runRecursively",
+          "Description": "bool",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -37,7 +46,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "Document.PurgeUnused ( ): string"
+      "Description": "Purge unused Elements from the model. This node is not able to purge materials and material assets\n\nDocument.PurgeUnused (runRecursively: bool): string"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -58,13 +67,38 @@
       ],
       "Replication": "Auto",
       "Description": "Get the current document\n\nDocument.Current: Document"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.BoolSelector, CoreNodeModels",
+      "NodeType": "BooleanInputNode",
+      "InputValue": true,
+      "Id": "3bff80c32bcb436e9e5b0c9b24ba760d",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "57c905adff5c414db87efcba669b8150",
+          "Name": "",
+          "Description": "Boolean",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Selection between a true and false."
     }
   ],
   "Connectors": [
     {
       "Start": "97a42bb3f8424d4bb4017a9901b14363",
       "End": "20ae7b8a1d484b36b41562aee7ea9741",
-      "Id": "522909a253204c95ae61bfb51f785830"
+      "Id": "7457b7a8f38b4fa49af2c1e27cde3ffd"
+    },
+    {
+      "Start": "57c905adff5c414db87efcba669b8150",
+      "End": "fe84fdef176b4cd6b126cb11691d8daa",
+      "Id": "2a225f9fec2743269c0ed690d0529a1d"
     }
   ],
   "Dependencies": [],
@@ -111,11 +145,21 @@
         "Excluded": false,
         "X": 97.333333333333314,
         "Y": 169.33333333333334
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Boolean",
+        "Id": "3bff80c32bcb436e9e5b0c9b24ba760d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 102.66666666666657,
+        "Y": 263.33333333333331
       }
     ],
     "Annotations": [],
-    "X": 0.0,
-    "Y": 0.0,
-    "Zoom": 1.0
+    "X": -109.58882235528941,
+    "Y": -89.349301397205579,
+    "Zoom": 1.4341317365269461
   }
 }


### PR DESCRIPTION
### Purpose

Adding Document.PurgeUnused node to the Application.Document category and tests

### Reviewers

@radumg 

### FYIs
The description in asana says to use PostableCommands, did some research and found this https://thebuildingcoder.typepad.com/blog/2018/08/purge-unused-using-performance-adviser.html which seems to be a better way of handling it. Only downside is that your are not able to purge materials and material assets that way.

#### Dynamo test file:
<img width="667" alt="PurgeUnused" src="https://user-images.githubusercontent.com/13732445/70903897-d63e1f00-1ff7-11ea-88ce-9a148bccef13.png">
